### PR TITLE
Fixed memory leak in release build + Moved async logic to sample app

### DIFF
--- a/CompanionWinRT/CMakeLists.txt
+++ b/CompanionWinRT/CMakeLists.txt
@@ -31,9 +31,9 @@ target_link_libraries(CompanionWinRT Companion)
 
 
 # add install instructions
-install(TARGETS CompanionWinRT EXPORT CompanionWinRTWrapperConfig
+install(TARGETS CompanionWinRT EXPORT CompanionWinRTConfig
         RUNTIME DESTINATION "bin"
         LIBRARY DESTINATION "lib"
         ARCHIVE DESTINATION "lib")
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} DESTINATION include FILES_MATCHING PATTERN "*.h")
-install(EXPORT CompanionWinRTWrapperConfig DESTINATION "lib")
+install(EXPORT CompanionWinRTConfig DESTINATION "lib")

--- a/CompanionWinRT/Configuration.cpp
+++ b/CompanionWinRT/Configuration.cpp
@@ -57,6 +57,7 @@ Configuration::Configuration()
 
 void Configuration::setProcessing(ObjectDetection^ detection)
 {
+    this->detection = detection;
     this->configurationObj.setProcessing(this->detection->getProcessing(&this->configurationObj));
 }
 
@@ -82,11 +83,13 @@ void Configuration::setPixelBuffer(IBuffer^ pixelBuffer)
 
 void Configuration::setSource(ImageStream^ stream)
 {
+    this->stream = stream;
     this->configurationObj.setSource(this->stream->getStream());
 }
 
 void Configuration::addModel(FeatureMatchingModel^ model)
 {
+    this->models.push_back(model);
     if (!this->configurationObj.addModel(model->getModel()))
     {
         int hresult = static_cast<int>(ErrorCode::model_not_added);

--- a/CompanionWinRT/Configuration.cpp
+++ b/CompanionWinRT/Configuration.cpp
@@ -42,40 +42,34 @@ CoreDispatcher^ Configuration::dispatcher = nullptr;
 
 Configuration::Configuration()
 {
-    this->configurationObj = new Companion::Configuration();
-
     // Define callback functions
     //std::function<void(std::vector<Companion::Draw::Drawable*>, cv::Mat)> callback = std::bind(&CallbackWrapper::callback, this->callbackWrapper, std::placeholders::_1, std::placeholders::_2);
     //std::function<void(std::vector<Companion::Draw::Drawable*>, cv::Mat)> callback = std::bind(&Configuration::callback, this, std::placeholders::_1, std::placeholders::_2);
-    this->configurationObj->setResultHandler(Configuration::callback);
+    this->configurationObj.setResultHandler(Configuration::callback);
     //std::function<void(Companion::Error::Code)> error = std::bind(&Configuration::error, this, std::placeholders::_1);
-    this->configurationObj->setErrorHandler(Configuration::error);
-}
-
-Configuration::~Configuration()
-{
-    delete this->configurationObj;
-    this->configurationObj = nullptr;
-}
-
-IAsyncAction^ Configuration::setProcessing(ObjectDetection^ detection)
-{
-    return create_async([this, detection]()
+    //this->configurationObj.setErrorHandler(Configuration::error);
+    this->configurationObj.setErrorHandler([](Companion::Error::Code code)
     {
-        this->configurationObj->setProcessing(detection->getProcessing(this->configurationObj));
+        int hresult = static_cast<int>(getErrorCode(code));
+        throw ref new Platform::Exception(hresult);
     });
 }
 
-IAsyncAction^ Configuration::setSkipFrame(int skipFrame)
+void Configuration::setProcessing(ObjectDetection^ detection)
 {
-    return create_async([this, skipFrame]()
-    {
-        this->configurationObj->setSkipFrame(0);
-    });
+    this->configurationObj.setProcessing(this->detection->getProcessing(&this->configurationObj));
+}
+
+void Configuration::setSkipFrame(int skipFrame)
+{
+    this->configurationObj.setSkipFrame(skipFrame);
 }
 
 void Configuration::setPixelBuffer(IBuffer^ pixelBuffer)
 {
+    // Define dispatcher for the UI thread
+    Configuration::dispatcher = CoreWindow::GetForCurrentThread()->Dispatcher;
+
     // Query the IBufferByteAccess interface.  
     Microsoft::WRL::ComPtr<IBufferByteAccess> bufferByteAccess;
     reinterpret_cast<IInspectable*>(pixelBuffer)->QueryInterface(IID_PPV_ARGS(&bufferByteAccess));
@@ -86,47 +80,54 @@ void Configuration::setPixelBuffer(IBuffer^ pixelBuffer)
     Configuration::pixels = pixels;
 }
 
-IAsyncAction^ Configuration::setSource(ImageStream^ stream)
+void Configuration::setSource(ImageStream^ stream)
 {
-    return create_async([this, stream]()
-    {
-        this->configurationObj->setSource(stream->getStream());
-    });
+    this->configurationObj.setSource(this->stream->getStream());
 }
 
-IAsyncAction^ Configuration::addModel(FeatureMatchingModel^ model)
+void Configuration::addModel(FeatureMatchingModel^ model)
 {
-    return create_async([this, model]()
+    if (!this->configurationObj.addModel(model->getModel()))
     {
-        if (!this->configurationObj->addModel(model->getModel()))
-        {
-            int hresult = static_cast<int>(ErrorCode::model_not_added);
-            throw ref new Platform::Exception(hresult);
-        }
-    });
+        int hresult = static_cast<int>(ErrorCode::model_not_added);
+        throw ref new Platform::Exception(hresult);
+    }
 }
 
-IAsyncAction^ Configuration::run()
+void Configuration::run()
 {
-    // Define dispatcher for the UI thread
-    Configuration::dispatcher = CoreWindow::GetForCurrentThread()->Dispatcher;
+    // Test
+    Configuration::getDataEvent += ref new GetDataDelegate(this, &Configuration::GetDataImpl2);
 
-    return create_async([this]()
+    // Create StreamWorker
+    std::queue<cv::Mat> queue;
+    Companion::Thread::StreamWorker ps(queue);
+
+    try
     {
-        std::queue<cv::Mat>* queue = new std::queue<cv::Mat>();
-        Companion::Thread::StreamWorker* ps = new Companion::Thread::StreamWorker(*queue);
+        this->configurationObj.run(ps);
+    }
+    catch (Companion::Error::Code errorCode)
+    {
+        Configuration::error(errorCode);
+    }
+}
 
-        Configuration::getDataEvent += ref new GetDataDelegate(this, &Configuration::GetDataImpl2);
+void Configuration::stop()
+{
+    try
+    {
+        this->configurationObj.stop();
+    }
+    catch (Companion::Error::Code errorCode)
+    {
+        Configuration::error(errorCode);
+    }
+}
 
-        try
-        {
-            this->configurationObj->run(*ps);
-        }
-        catch (Companion::Error::Code errorCode)
-        {
-            Configuration::error(errorCode);
-        }
-    });
+int Configuration::getSkipFrame()
+{
+    return this->configurationObj.getSkipFrame();
 }
 
 /* Videos as source are not supported right now. You have to build FFMpeg for OpenCV and WinRT.
@@ -162,6 +163,7 @@ void Configuration::error(Companion::Error::Code code)
 
 void Configuration::callback(std::vector<Companion::Draw::Drawable*> objects, cv::Mat frame)
 {
+    // Draw found objects onto the frame
     Companion::Draw::Drawable *drawable;
 
     for (int x = 0; x < objects.size(); x++)
@@ -224,6 +226,7 @@ void Configuration::GetDataImpl(std::vector<Companion::Draw::Drawable*> objects,
 
 void Configuration::GetDataImpl2(std::vector<Companion::Draw::Drawable*> objects, cv::Mat frame)
 {
+    // Draw found objects onto the frame
     Companion::Draw::Drawable *drawable;
 
     for (int x = 0; x < objects.size(); x++)

--- a/CompanionWinRT/Configuration.h
+++ b/CompanionWinRT/Configuration.h
@@ -57,11 +57,6 @@ namespace CompanionWinRT
             Configuration();
 
             /**
-             * Destructs this instance.
-             */
-            virtual ~Configuration();
-
-            /**
              * Sets the image processing configuration.
              *
              * Note:
@@ -69,14 +64,14 @@ namespace CompanionWinRT
              * plausible abstract class 'ImageProcessing' for this wrapper. This is a minum construct and has to be
              * further developed to provide the same flexability as the Companion native DLL.
              */
-            IAsyncAction^ setProcessing(ObjectDetection^ detection);
+            void setProcessing(ObjectDetection^ detection);
 
             /**
              * Sets the number of frames to skip.
              *
              * @param skipFrame number of frames which should be skipped after one image processing cycle
              */
-            IAsyncAction^ setSkipFrame(int skipFrame);
+            void setSkipFrame(int skipFrame);
 
             /**
              * Sets the source.
@@ -86,19 +81,24 @@ namespace CompanionWinRT
              * plausible abstract class 'Stream' for this wrapper. This is a minum construct and has to be
              * further developed to provide the same flexability as the Companion native DLL.
              */
-            IAsyncAction^ setSource(ImageStream^ stream);
+            void setSource(ImageStream^ stream);
 
             /**
              * Adds a 'FeatureMatchingModel' object to this companion configuration.
              *
              * @param model feature matching model that is going to be added to this companion configuration
              */
-            IAsyncAction^ addModel(FeatureMatchingModel^ model);
+            void addModel(FeatureMatchingModel^ model);
 
             /**
              * Starts processing of the Companion library.
              */
-            IAsyncAction^ run();
+            void run();
+
+            /**
+             * Stops processing of the Companion library.
+             */
+            void stop();
 
             /**
              * Static event to update a listener that a new image is available.
@@ -115,12 +115,18 @@ namespace CompanionWinRT
 
             //static Platform::String^ loadVideo(Platform::String^ videoPath);
 
+            /**
+             * Returns the skip frame rate.
+             * @return number of frames that are skipped after each processed frame
+             */
+            int getSkipFrame();
+
         private:
         
             /**
              * The native 'Configuration' object of this instance.
              */
-            Companion::Configuration* configurationObj;
+            Companion::Configuration configurationObj;
 
             /*********************************************************************************************************
              * Raw pixel data (bytes) of the WritableBitmap that represents the companion output ont the UI thread.

--- a/CompanionWinRT/Configuration.h
+++ b/CompanionWinRT/Configuration.h
@@ -52,7 +52,7 @@ namespace CompanionWinRT
         public:
 
             /**
-             * Creates an 'Companion/Configuration' wrapper.
+             * Creates an 'Configuration' wrapper.
              */
             Configuration();
 
@@ -118,19 +118,19 @@ namespace CompanionWinRT
         private:
         
             /**
-             * The native 'Companion/Configuration' object of this instance.
+             * The native 'Configuration' object of this instance.
              */
             Companion::Configuration* configurationObj;
 
             /*********************************************************************************************************
-            * Raw pixel data (bytes) of the WritableBitmap that represents the companion output ont the UI thread.
-            *********************************************************************************************************/
+             * Raw pixel data (bytes) of the WritableBitmap that represents the companion output ont the UI thread.
+             *********************************************************************************************************/
             static uint8* pixels;
 
             /*********************************************************************************************************
-            * Static dispatcher that is responsible to dispathc the triggered 'featuresFoundEvent' to get delivered
-            * to the right thread (in this current context that is the UI thread).
-            *********************************************************************************************************/
+             * Static dispatcher that is responsible to dispathc the triggered 'featuresFoundEvent' to get delivered
+             * to the right thread (in this current context that is the UI thread).
+             *********************************************************************************************************/
             static CoreDispatcher^ dispatcher;
 
             /**

--- a/CompanionWinRT/Configuration.h
+++ b/CompanionWinRT/Configuration.h
@@ -128,6 +128,21 @@ namespace CompanionWinRT
              */
             Companion::Configuration configurationObj;
 
+            /**
+             * A handle to the 'ObjectDetection' wrapper object.
+             */
+            ObjectDetection^ detection;
+
+            /**
+             * A handle to the 'ImageStream' wrapper object.
+             */
+            ImageStream^ stream;
+
+            /**
+             * A collection of all feature matching models.
+             */
+            std::vector<FeatureMatchingModel^> models;
+
             /*********************************************************************************************************
              * Raw pixel data (bytes) of the WritableBitmap that represents the companion output ont the UI thread.
              *********************************************************************************************************/

--- a/CompanionWinRT/model/FeatureMatchingModel.cpp
+++ b/CompanionWinRT/model/FeatureMatchingModel.cpp
@@ -21,8 +21,6 @@
 #include "FeatureMatchingModel.h"
 #include "..\utils\CompanionError.h"
 
-#include <opencv2\imgcodecs\imgcodecs.hpp>
-
 using namespace CompanionWinRT;
 
 FeatureMatchingModel::FeatureMatchingModel(Platform::String^ imagePath)
@@ -30,7 +28,8 @@ FeatureMatchingModel::FeatureMatchingModel(Platform::String^ imagePath)
     if (imagePath != nullptr)
     {
         this->featureMatchingModelObj = new Companion::Model::FeatureMatchingModel();
-        this->featureMatchingModelObj->setImage(cv::imread(ps2ss(imagePath), cv::IMREAD_GRAYSCALE)); // ToDO: should the user be able to change IMREAD value?
+        this->imageModel = cv::imread(ps2ss(imagePath), cv::IMREAD_GRAYSCALE); // ToDO: should the user be able to change IMREAD value?
+        this->featureMatchingModelObj->setImage(this->imageModel);
         
         /* ToDo for wrapper: construct 'FeatureMatchingModel' with a reference to 'CPUFeatureMatching' */
         // Only works on CPU -- ToDo Exception Handling if wrong type?

--- a/CompanionWinRT/model/FeatureMatchingModel.h
+++ b/CompanionWinRT/model/FeatureMatchingModel.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <opencv2\imgcodecs\imgcodecs.hpp>
+
 #include <companion\model\FeatureMatchingModel.h>
 
 namespace CompanionWinRT
@@ -55,6 +57,11 @@ namespace CompanionWinRT
          * The native 'FeatureMatchingModel' object of this instance.
          */
         Companion::Model::FeatureMatchingModel* featureMatchingModelObj;
+
+        /**
+         * The native 'cv:Mat' object of this model.
+         */
+        cv::Mat imageModel;
 
     internal:
 

--- a/CompanionWinRT/model/FeatureMatchingModel.h
+++ b/CompanionWinRT/model/FeatureMatchingModel.h
@@ -35,7 +35,7 @@ namespace CompanionWinRT
      */
     public ref class FeatureMatchingModel sealed
     {
-        public:
+    public:
 
         /**
          * Creates an 'FeatureMatchingModel' wrapper with the provided image path.
@@ -49,14 +49,14 @@ namespace CompanionWinRT
          */
         virtual ~FeatureMatchingModel();
 
-        private:
+    private:
 
         /**
          * The native 'FeatureMatchingModel' object of this instance.
          */
         Companion::Model::FeatureMatchingModel* featureMatchingModelObj;
 
-        internal:
+    internal:
 
         /**
          * Internal method to provide the native 'ImageRecognitionModel' object (in this case an 'FeatureMatchingModel' object).

--- a/CompanionWinRT/processing/2D/ObjectDetection.h
+++ b/CompanionWinRT/processing/2D/ObjectDetection.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include <companion\Companion.h>
+#include <companion\Configuration.h>
 #include <companion\processing\2D\ObjectDetection.h>
 
 #include "..\..\algo\CPUFeatureMatching.h"

--- a/CompanionWinRT/processing/2D/ObjectDetection.h
+++ b/CompanionWinRT/processing/2D/ObjectDetection.h
@@ -41,81 +41,81 @@ namespace CompanionWinRT
      */
     public ref class ObjectDetection sealed
     {
-        public:
+    public:
 
-            /**
-             * Creates an 'ObjectDetection' wrapper with the provided feature matching algorithm.
-             *
-             * Note:
-             * Public inheritance is not possible in a WinRT context (with very few exceptions). We can not mirror the
-             * plausible abstract class 'ImageProcessing' for this wrapper. To avoid circular dependencies (includes)
-             * the companion/configuration reference has to be provided natively inside the 'Configuration' wrapper.
-             *
-             * ToDo:
-             * User should be able to choose between different image recognition algorithms. This is a minimum construction.
-             *
-             * @param feature       Image recognition algorithm to use, for example feature matching.
-             */
-            ObjectDetection(CPUFeatureMatching^ feature) : ObjectDetection(feature, 0.5F)
-            {};
+        /**
+         * Creates an 'ObjectDetection' wrapper with the provided feature matching algorithm.
+         *
+         * Note:
+         * Public inheritance is not possible in a WinRT context (with very few exceptions). We can not mirror the
+         * plausible abstract class 'ImageProcessing' for this wrapper. To avoid circular dependencies (includes)
+         * the configuration reference has to be provided natively inside the 'Configuration' wrapper.
+         *
+         * ToDo:
+         * User should be able to choose between different image recognition algorithms. This is a minimum construction.
+         *
+         * @param feature       Image recognition algorithm to use, for example feature matching.
+         */
+        ObjectDetection(CPUFeatureMatching^ feature) : ObjectDetection(feature, 0.5F)
+        {};
 
-            /**
-             * Creates an 'ObjectDetection' wrapper with the provided feature matching algorithm.
-             *
-             * Note:
-             * Public inheritance is not possible in a WinRT context (with very few exceptions). We can not mirror the
-             * plausible abstract class 'ImageProcessing' for this wrapper. To avoid circular dependencies (includes)
-             * the companion/configuration reference has to be provided natively inside the 'Configuration' wrapper.
-             *
-             * ToDo:
-             * User should be able to choose between different image recognition algorithms. This is a minimum construction.
-             *
-             * @param feature       Image recognition algorithm to use, for example feature matching.
-             * @param scale         scaling factor of frames
-             */
-            ObjectDetection(CPUFeatureMatching^ feature, float scale);
+        /**
+         * Creates an 'ObjectDetection' wrapper with the provided feature matching algorithm.
+         *
+         * Note:
+         * Public inheritance is not possible in a WinRT context (with very few exceptions). We can not mirror the
+         * plausible abstract class 'ImageProcessing' for this wrapper. To avoid circular dependencies (includes)
+         * the configuration reference has to be provided natively inside the 'Configuration' wrapper.
+         *
+         * ToDo:
+         * User should be able to choose between different image recognition algorithms. This is a minimum construction.
+         *
+         * @param feature       Image recognition algorithm to use, for example feature matching.
+         * @param scale         scaling factor of frames
+         */
+        ObjectDetection(CPUFeatureMatching^ feature, float scale);
 
-            /**
-             * Destructs this instance.
-             */
-            virtual ~ObjectDetection();
+        /**
+         * Destructs this instance.
+         */
+        virtual ~ObjectDetection();
 
-        private:
+    private:
 
-            /**
-             * The native 'ObjectDetection' object of this instance.
-             */
-            Companion::Processing::ObjectDetection* objectDetectionObj;
+        /**
+         * The native 'ObjectDetection' object of this instance.
+         */
+        Companion::Processing::ObjectDetection* objectDetectionObj;
 
-            /**
-             * A handle to the desired image recognition algorithm.
-             *
-             * Note:
-             * Public inheritance is not possible in a WinRT context (with very few exceptions). We can not mirror the
-             * plausible abstract class 'ImageProcessing' for this wrapper.
-             *
-             * ToDo:
-             * User should be able to choose between different image recognition algorithms. This is a minimum construction.
-             */
-            CPUFeatureMatching^ feature;
+        /**
+         * A handle to the desired image recognition algorithm.
+         *
+         * Note:
+         * Public inheritance is not possible in a WinRT context (with very few exceptions). We can not mirror the
+         * plausible abstract class 'ImageProcessing' for this wrapper.
+         *
+         * ToDo:
+         * User should be able to choose between different image recognition algorithms. This is a minimum construction.
+         */
+        CPUFeatureMatching^ feature;
 
-            /**
-             * Scaling factor for frames.
-             */
-            float scale;
+        /**
+         * Scaling factor for frames.
+         */
+        float scale;
 
-        internal:
+    internal:
 
-            /**
-             * Internal method to provide the native 'ImageProcessing' object (in this case a 'ObjectDetection' object).
-             *
-             * Note:
-             * Public inheritance is not possible in a WinRT context (with very few exceptions). We can not mirror the
-             * plausible abstract class 'ImageProcessing' for this wrapper. To avoid circular dependencies (includes)
-             * the companion/configuration reference has to be provided natively inside the 'Configuration' wrapper.
-             *
-             * @return Pointer to the native 'ImageProcessing' object
-             */
-            Companion::Processing::ImageProcessing* getProcessing(Companion::Configuration* configuration);
+        /**
+         * Internal method to provide the native 'ImageProcessing' object (in this case a 'ObjectDetection' object).
+         *
+         * Note:
+         * Public inheritance is not possible in a WinRT context (with very few exceptions). We can not mirror the
+         * plausible abstract class 'ImageProcessing' for this wrapper. To avoid circular dependencies (includes)
+         * the configuration reference has to be provided natively inside the 'Configuration' wrapper.
+         *
+         * @return Pointer to the native 'ImageProcessing' object
+         */
+        Companion::Processing::ImageProcessing* getProcessing(Companion::Configuration* configuration);
     };
 }

--- a/CompanionWinRT/utils/CompanionError.h
+++ b/CompanionWinRT/utils/CompanionError.h
@@ -129,7 +129,7 @@ namespace CompanionWinRT
                         error = "The handle to the CPUFeatureMatching object is null.";
                         break;
                     case ErrorCode::config_or_recognition_not_found :
-                        error = "At least one of the provided pointers/handles to the 'Companion/Configuration' and 'CPUFeatureMatching' objects is null.";
+                        error = "At least one of the provided pointers/handles to the 'Configuration' and 'CPUFeatureMatching' objects is null.";
                         break;
                     case ErrorCode::objectdetection_not_found :
                         error = "The handle that points to the 'ObjectDetection' objects is null.";


### PR DESCRIPTION
- fixed memory leak in release build
- moved async logic from wrapper to sample app (should be handled in app logic)
- included cancellation logic (processing has to be explicitly stopped now)
- changed asset and image source folder access in sample app
- implemented getSkripFrame()